### PR TITLE
[FEAT] 폰트 생성 결과 DB에 저장

### DIFF
--- a/backend/.claude/settings.local.json
+++ b/backend/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./mvnw compile *)",
+      "Bash(./gradlew compileJava -q)",
+      "Bash(xargs ls)",
+      "Bash(git add *)",
+      "Bash(git rm *)",
+      "Bash(git reset *)"
+    ]
+  }
+}

--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
       .authorizeHttpRequests(auth -> auth
         .requestMatchers("/api/v1/auth/**").permitAll()
         .requestMatchers("/api/v1/autobiography/**").permitAll()
+        .requestMatchers("/api/v1/fonts/**").permitAll()
         .anyRequest().authenticated()
       );
 

--- a/backend/src/main/java/com/example/backend/controller/FontController.java
+++ b/backend/src/main/java/com/example/backend/controller/FontController.java
@@ -1,5 +1,7 @@
 package com.example.backend.controller;
 
+import com.example.backend.dto.FontListResponse;
+import com.example.backend.entity.Font;
 import com.example.backend.service.FontService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
@@ -25,6 +27,8 @@ public class FontController {
     @PostMapping("/upload")
     public ResponseEntity<?> uploadImages(
         @RequestParam("files") List<MultipartFile> files,
+        @RequestParam("fontName") String fontName,
+        @RequestParam(value = "type", defaultValue = "MANUAL") Font.FontType type,
         @CookieValue(name = "accessToken", required = false) String token
     ) {
         if (token == null) {
@@ -34,8 +38,8 @@ public class FontController {
             return ResponseEntity.badRequest().body("업로드할 이미지가 없습니다.");
         }
         try {
-            String fontId = fontService.uploadFont(files, token);
-            return ResponseEntity.ok(Map.of("fontId", fontId, "message", "폰트 생성 완료"));
+            String fontId = fontService.uploadFont(files, token, fontName, type);
+            return ResponseEntity.ok(Map.of("fontId", fontId, "fontName", fontName, "message", "폰트 생성 완료"));
         } catch (RuntimeException e) {
             return ResponseEntity.status(401).body(e.getMessage());
         } catch (Exception e) {
@@ -44,19 +48,37 @@ public class FontController {
         }
     }
 
-    @GetMapping("/download")
+    @GetMapping("/list")
+    public ResponseEntity<?> getMyFonts(
+        @CookieValue(name = "accessToken", required = false) String token
+    ) {
+        if (token == null) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
+        }
+        try {
+            List<FontListResponse> fonts = fontService.getMyFonts(token)
+                .stream().map(FontListResponse::new).toList();
+            return ResponseEntity.ok(fonts);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(401).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/download/{fontId}")
     public ResponseEntity<Resource> downloadFont(
+        @PathVariable String fontId,
         @CookieValue(name = "accessToken", required = false) String token
     ) {
         if (token == null) {
             return ResponseEntity.status(401).build();
         }
         try {
-            File ttfFile = fontService.downloadFont(token);
+            File ttfFile = fontService.downloadFont(token, fontId);
             Resource resource = new UrlResource(ttfFile.toURI());
+            String fileName = ttfFile.getName();
             return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"MyHandwriting.ttf\"")
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
                 .body(resource);
         } catch (RuntimeException e) {
             return ResponseEntity.status(404).build();

--- a/backend/src/main/java/com/example/backend/controller/FontController.java
+++ b/backend/src/main/java/com/example/backend/controller/FontController.java
@@ -1,5 +1,7 @@
 package com.example.backend.controller;
 
+import com.example.backend.service.FontService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpHeaders;
@@ -8,122 +10,59 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStreamReader;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/fonts")
 @CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
 public class FontController {
 
-  @PostMapping("/upload")
-  public String uploadImages(@RequestParam("files") List<MultipartFile> files) {
-    if (files == null || files.isEmpty()) {
-      return "실패: 업로드할 이미지가 없습니다.";
-    }
+    private final FontService fontService;
 
-    try {
-      String jobId = UUID.randomUUID().toString();
-      String baseDir = System.getProperty("user.dir"); // FFH/backend 폴더
-      String uploadPath = Paths.get(baseDir, "uploads", jobId).toString();
-
-      saveFiles(files, uploadPath);
-
-      String pythonScriptPath = Paths.get(baseDir, "..", "font-engine", "main.py").normalize().toString();
-      String outputTtfPath = Paths.get(uploadPath, "MyHandwriting.ttf").toString();
-
-      boolean isSuccess = runPythonEngine(pythonScriptPath, uploadPath, outputTtfPath);
-
-      if (isSuccess) {
-        return "성공: 폰트 생성 완료! (ID: " + jobId + ")";
-      } else {
-        return "실패: 파이썬 폰트 생성 중 에러 발생";
-      }
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      return "에러 발생: " + e.getMessage();
-    }
-  }
-
-  @GetMapping("/download")
-  public ResponseEntity<Resource> downloadFont() {
-    try {
-      String baseDir = System.getProperty("user.dir");
-      File uploadsDir = new File(baseDir, "uploads");
-
-      File[] jobDirs = uploadsDir.listFiles(File::isDirectory);
-      if (jobDirs == null || jobDirs.length == 0) {
-        return ResponseEntity.notFound().build();
-      }
-
-      File latestDir = jobDirs[0];
-      for (File dir : jobDirs) {
-        if (dir.lastModified() > latestDir.lastModified()) {
-          latestDir = dir;
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadImages(
+        @RequestParam("files") List<MultipartFile> files,
+        @CookieValue(name = "accessToken", required = false) String token
+    ) {
+        if (token == null) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
         }
-      }
-
-      File ttfFile = new File(latestDir, "MyHandwriting.ttf");
-      if (!ttfFile.exists()) {
-        return ResponseEntity.notFound().build();
-      }
-
-      Resource resource = new UrlResource(ttfFile.toURI());
-
-      return ResponseEntity.ok()
-        .contentType(MediaType.APPLICATION_OCTET_STREAM)
-        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"MyHandwriting.ttf\"")
-        .body(resource);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      return ResponseEntity.internalServerError().build();
+        if (files == null || files.isEmpty()) {
+            return ResponseEntity.badRequest().body("업로드할 이미지가 없습니다.");
+        }
+        try {
+            String fontId = fontService.uploadFont(files, token);
+            return ResponseEntity.ok(Map.of("fontId", fontId, "message", "폰트 생성 완료"));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(401).body(e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body("에러 발생: " + e.getMessage());
+        }
     }
-  }
 
-  private void saveFiles(List<MultipartFile> files, String uploadPath) throws Exception {
-    File directory = new File(uploadPath);
-    if (!directory.exists()) directory.mkdirs();
-
-    for (MultipartFile file : files) {
-      String originalName = file.getOriginalFilename();
-      if (originalName == null) continue;
-
-      String fileNameOnly = originalName.replaceAll("[^0-9]", "");
-      String saveName;
-      if (!fileNameOnly.isEmpty()) {
-        int fileNumber = Integer.parseInt(fileNameOnly);
-        saveName = String.format("%02d.jpg", fileNumber);
-      } else {
-        saveName = originalName;
-      }
-
-      file.transferTo(new File(uploadPath + File.separator + saveName));
+    @GetMapping("/download")
+    public ResponseEntity<Resource> downloadFont(
+        @CookieValue(name = "accessToken", required = false) String token
+    ) {
+        if (token == null) {
+            return ResponseEntity.status(401).build();
+        }
+        try {
+            File ttfFile = fontService.downloadFont(token);
+            Resource resource = new UrlResource(ttfFile.toURI());
+            return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"MyHandwriting.ttf\"")
+                .body(resource);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(404).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().build();
+        }
     }
-  }
-  
-  private boolean runPythonEngine(String scriptPath, String inputDir, String outputTtfPath) {
-    try {
-      ProcessBuilder pb = new ProcessBuilder("python3", "-u", scriptPath, inputDir, outputTtfPath);
-      pb.redirectErrorStream(true);
-      Process process = pb.start();
-
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-      String line;
-      while ((line = reader.readLine()) != null) {
-        System.out.println("[Python Log] " + line);
-      }
-
-      int exitCode = process.waitFor();
-      return exitCode == 0;
-    } catch (Exception e) {
-      e.printStackTrace();
-      return false;
-    }
-  }
 }

--- a/backend/src/main/java/com/example/backend/dto/FontListResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/FontListResponse.java
@@ -1,0 +1,22 @@
+package com.example.backend.dto;
+
+import com.example.backend.entity.Font;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FontListResponse {
+
+    private final String fontId;
+    private final String fontName;
+    private final String type;
+    private final LocalDateTime createdAt;
+
+    public FontListResponse(Font font) {
+        this.fontId = font.getFontId();
+        this.fontName = font.getFontName();
+        this.type = font.getType().name();
+        this.createdAt = font.getCreatedAt();
+    }
+}

--- a/backend/src/main/java/com/example/backend/entity/Font.java
+++ b/backend/src/main/java/com/example/backend/entity/Font.java
@@ -29,14 +29,23 @@ public class Font {
     @Column(nullable = false)
     private String ttfPath;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FontType type;
+
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public Font(User user, String fontName, String fontId, String ttfPath) {
+    public enum FontType {
+        MANUAL, AI
+    }
+
+    public Font(User user, String fontName, String fontId, String ttfPath, FontType type) {
         this.user = user;
         this.fontName = fontName;
         this.fontId = fontId;
         this.ttfPath = ttfPath;
+        this.type = type;
         this.createdAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/example/backend/entity/Font.java
+++ b/backend/src/main/java/com/example/backend/entity/Font.java
@@ -1,0 +1,42 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fonts")
+@Getter
+@NoArgsConstructor
+public class Font {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String fontName;
+
+    @Column(nullable = false, unique = true)
+    private String fontId;
+
+    @Column(nullable = false)
+    private String ttfPath;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public Font(User user, String fontName, String fontId, String ttfPath) {
+        this.user = user;
+        this.fontName = fontName;
+        this.fontId = fontId;
+        this.ttfPath = ttfPath;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/example/backend/repository/FontRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/FontRepository.java
@@ -1,0 +1,13 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Font;
+import com.example.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FontRepository extends JpaRepository<Font, Long> {
+    List<Font> findByUserOrderByCreatedAtDesc(User user);
+    Optional<Font> findByFontId(String fontId);
+}

--- a/backend/src/main/java/com/example/backend/service/FontService.java
+++ b/backend/src/main/java/com/example/backend/service/FontService.java
@@ -41,6 +41,8 @@ public class FontService {
             throw new RuntimeException("파이썬 폰트 생성 중 에러 발생");
         }
 
+        deleteJpgFiles(uploadPath);
+
         fontRepository.save(new Font(user, fontName, fontId, outputTtfPath, type));
         return fontId;
     }
@@ -92,6 +94,15 @@ public class FontService {
                 saveName = originalName;
             }
             file.transferTo(new File(uploadPath + File.separator + saveName));
+        }
+    }
+
+    private void deleteJpgFiles(String uploadPath) {
+        File[] jpgFiles = new File(uploadPath).listFiles(
+            f -> f.getName().toLowerCase().endsWith(".jpg") || f.getName().toLowerCase().endsWith(".jpeg")
+        );
+        if (jpgFiles != null) {
+            for (File jpg : jpgFiles) jpg.delete();
         }
     }
 

--- a/backend/src/main/java/com/example/backend/service/FontService.java
+++ b/backend/src/main/java/com/example/backend/service/FontService.java
@@ -1,0 +1,111 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Font;
+import com.example.backend.entity.User;
+import com.example.backend.repository.FontRepository;
+import com.example.backend.repository.UserRepository;
+import com.example.backend.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FontService {
+
+    private final FontRepository fontRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public String uploadFont(List<MultipartFile> files, String token) throws Exception {
+        User user = getUserFromToken(token);
+
+        String fontId = UUID.randomUUID().toString();
+        String baseDir = System.getProperty("user.dir");
+        String uploadPath = Paths.get(baseDir, "uploads", fontId).toString();
+
+        saveFiles(files, uploadPath);
+
+        String pythonScriptPath = Paths.get(baseDir, "..", "font-engine", "main.py").normalize().toString();
+        String outputTtfPath = Paths.get(uploadPath, "MyHandwriting.ttf").toString();
+
+        boolean success = runPythonEngine(pythonScriptPath, uploadPath, outputTtfPath);
+        if (!success) {
+            throw new RuntimeException("파이썬 폰트 생성 중 에러 발생");
+        }
+
+        fontRepository.save(new Font(user, "MyHandwriting", fontId, outputTtfPath));
+        return fontId;
+    }
+
+    @Transactional(readOnly = true)
+    public File downloadFont(String token) {
+        User user = getUserFromToken(token);
+
+        Font font = fontRepository.findByUserOrderByCreatedAtDesc(user)
+            .stream().findFirst()
+            .orElseThrow(() -> new RuntimeException("생성된 폰트가 없습니다."));
+
+        File ttfFile = new File(font.getTtfPath());
+        if (!ttfFile.exists()) {
+            throw new RuntimeException("폰트 파일을 찾을 수 없습니다.");
+        }
+        return ttfFile;
+    }
+
+    private User getUserFromToken(String token) {
+        if (token == null || !jwtProvider.validateToken(token)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+        String email = jwtProvider.getEmailFromToken(token);
+        return userRepository.findByEmail(email)
+            .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+    }
+
+    private void saveFiles(List<MultipartFile> files, String uploadPath) throws Exception {
+        File directory = new File(uploadPath);
+        if (!directory.exists()) directory.mkdirs();
+
+        for (MultipartFile file : files) {
+            String originalName = file.getOriginalFilename();
+            if (originalName == null) continue;
+
+            String fileNameOnly = originalName.replaceAll("[^0-9]", "");
+            String saveName;
+            if (!fileNameOnly.isEmpty()) {
+                int fileNumber = Integer.parseInt(fileNameOnly);
+                saveName = String.format("%02d.jpg", fileNumber);
+            } else {
+                saveName = originalName;
+            }
+            file.transferTo(new File(uploadPath + File.separator + saveName));
+        }
+    }
+
+    private boolean runPythonEngine(String scriptPath, String inputDir, String outputTtfPath) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("python3", "-u", scriptPath, inputDir, outputTtfPath);
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                System.out.println("[Python Log] " + line);
+            }
+
+            int exitCode = process.waitFor();
+            return exitCode == 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/backend/service/FontService.java
+++ b/backend/src/main/java/com/example/backend/service/FontService.java
@@ -24,7 +24,7 @@ public class FontService {
     private final JwtProvider jwtProvider;
 
     @Transactional
-    public String uploadFont(List<MultipartFile> files, String token) throws Exception {
+    public String uploadFont(List<MultipartFile> files, String token, String fontName, Font.FontType type) throws Exception {
         User user = getUserFromToken(token);
 
         String fontId = UUID.randomUUID().toString();
@@ -34,24 +34,30 @@ public class FontService {
         saveFiles(files, uploadPath);
 
         String pythonScriptPath = Paths.get(baseDir, "..", "font-engine", "main.py").normalize().toString();
-        String outputTtfPath = Paths.get(uploadPath, "MyHandwriting.ttf").toString();
+        String outputTtfPath = Paths.get(uploadPath, fontName + ".ttf").toString();
 
         boolean success = runPythonEngine(pythonScriptPath, uploadPath, outputTtfPath);
         if (!success) {
             throw new RuntimeException("파이썬 폰트 생성 중 에러 발생");
         }
 
-        fontRepository.save(new Font(user, "MyHandwriting", fontId, outputTtfPath));
+        fontRepository.save(new Font(user, fontName, fontId, outputTtfPath, type));
         return fontId;
     }
 
     @Transactional(readOnly = true)
-    public File downloadFont(String token) {
+    public List<Font> getMyFonts(String token) {
+        User user = getUserFromToken(token);
+        return fontRepository.findByUserOrderByCreatedAtDesc(user);
+    }
+
+    @Transactional(readOnly = true)
+    public File downloadFont(String token, String fontId) {
         User user = getUserFromToken(token);
 
-        Font font = fontRepository.findByUserOrderByCreatedAtDesc(user)
-            .stream().findFirst()
-            .orElseThrow(() -> new RuntimeException("생성된 폰트가 없습니다."));
+        Font font = fontRepository.findByFontId(fontId)
+            .filter(f -> f.getUser().getId().equals(user.getId()))
+            .orElseThrow(() -> new RuntimeException("폰트를 찾을 수 없습니다."));
 
         File ttfFile = new File(font.getTtfPath());
         if (!ttfFile.exists()) {

--- a/frontend/app/scan/page.tsx
+++ b/frontend/app/scan/page.tsx
@@ -11,7 +11,7 @@ import {
   Loader2,
   CheckCircle2,
 } from "lucide-react";
-import axios from "axios";
+import api from "@/app/lib/axios";
 import { useRouter } from "next/navigation";
 
 export default function ScanPage() {
@@ -20,6 +20,7 @@ export default function ScanPage() {
     "upload" | "draw" | null
   >(null);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [fontName, setFontName] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [isProcessing, setIsProcessing] = useState(false);
@@ -58,6 +59,10 @@ export default function ScanPage() {
       alert("파일을 먼저 업로드해 주세요!");
       return;
     }
+    if (!fontName.trim()) {
+      alert("폰트 이름을 입력해 주세요!");
+      return;
+    }
 
     setIsProcessing(true);
     setProgress(0);
@@ -66,24 +71,20 @@ export default function ScanPage() {
     selectedFiles.forEach((file) => {
       formData.append("files", file);
     });
+    formData.append("fontName", fontName.trim());
+    formData.append("type", "MANUAL");
 
     try {
-      const response = await axios.post(
-        "http://localhost:8080/api/v1/fonts/upload",
-        formData,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
-          },
-        },
-      );
-      if (response.status === 200) {
-        setProgress(100);
-        setTimeout(() => {
-          alert("성공적으로 폰트가 생성되었습니다!");
-          router.push("/scan/result");
-        }, 500);
-      }
+      const response = await api.post("/fonts/upload", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+        timeout: 600000,
+      });
+      setProgress(100);
+      localStorage.setItem("lastFontId", response.data.fontId);
+      localStorage.setItem("lastFontName", response.data.fontName);
+      setTimeout(() => {
+        router.push("/scan/result");
+      }, 500);
     } catch (error) {
       console.error("전송 실패:", error);
       alert("폰트 생성 중 서버 오류가 발생했습니다.");
@@ -205,6 +206,19 @@ export default function ScanPage() {
                   클릭하여 이미지들을 선택하세요
                 </p>
                 <p className="text-gray-400 text-xs">최대 18장 권장</p>
+              </div>
+
+              <div className="mt-8">
+                <label className="block text-sm font-bold text-gray-700 mb-2">
+                  폰트 이름
+                </label>
+                <input
+                  type="text"
+                  value={fontName}
+                  onChange={(e) => setFontName(e.target.value)}
+                  placeholder="예: 할머니체, 내손글씨"
+                  className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-purple-400 text-gray-800"
+                />
               </div>
 
               {selectedFiles.length > 0 && (

--- a/frontend/app/scan/result/page.tsx
+++ b/frontend/app/scan/result/page.tsx
@@ -1,12 +1,40 @@
 "use client";
 
-import React from "react";
+import { useEffect, useState } from "react";
 import { Check, Download, Info, ArrowRight } from "lucide-react";
+import api from "@/app/lib/axios";
 
 export default function ResultPage() {
-  const handleDownloadTTF = () => {
-    const downloadUrl = "http://localhost:8080/api/v1/fonts/download";
-    window.location.href = downloadUrl;
+  const [fontId, setFontId] = useState<string | null>(null);
+  const [fontName, setFontName] = useState("MyFont");
+
+  useEffect(() => {
+    const id = localStorage.getItem("lastFontId");
+    const name = localStorage.getItem("lastFontName");
+    if (id) setFontId(id);
+    if (name) setFontName(name);
+  }, []);
+
+  const handleDownloadTTF = async () => {
+    if (!fontId) {
+      alert("다운로드할 폰트 정보가 없습니다.");
+      return;
+    }
+    try {
+      const response = await api.get(`/fonts/download/${fontId}`, {
+        responseType: "blob",
+      });
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${fontName}.ttf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch {
+      alert("다운로드 중 오류가 발생했습니다.");
+    }
   };
 
   const handleDownloadWOFF2 = () => {
@@ -68,7 +96,7 @@ export default function ResultPage() {
           <h3 className="text-lg font-bold mb-6">다운로드</h3>
           <div className="flex flex-col gap-4">
             <DownloadButton
-              label="MyFont.ttf"
+              label={`${fontName}.ttf`}
               subLabel="TTF 포맷"
               onClick={handleDownloadTTF}
             />


### PR DESCRIPTION
## #️⃣연관된 이슈
closed #13 

## 📝작업 내용

**[backend] Font 엔티티 및 DB 연동**

- [x] `Font` 엔티티 생성 (user FK, fontName, fontId, ttfPath, type[MANUAL/AI], createdAt)
- [x] `FontRepository`, `FontService`, `FontListResponse` DTO 생성
- [x] `FontController` 수정 — JWT 쿠키 인증 추가, fontName/type 파라미터 수신
- [x] `GET /api/v1/fonts/list` — 내 폰트 목록 조회 엔드포인트 추가
- [x] `GET /api/v1/fonts/download/{fontId}` — fontId 기반 다운로드로 변경 (본인 소유 검증 포함)
- [x] `SecurityConfig` — `/api/v1/fonts/**` permitAll 추가

**[frontend/app/scan] 폰트 이름 입력 및 API 연동**

- [x] 폰트 이름 입력 필드 UI 추가
- [x] raw axios → 인증 api 인스턴스로 교체 (쿠키 자동 포함)
- [x] 업로드 시 `fontName`, `type` 파라미터 전송
- [x] 생성 완료 후 `fontId`, `fontName` localStorage 저장

**[frontend/app/scan/result] 결과 페이지 실제 연동**

- [x] localStorage에서 fontId/fontName 읽어 다운로드 연결- [x] blob 방식 다운로드로 변경 → 파일명 `폰트이름.ttf` 로 정상 저장

---

### ⚠️ Pull 받을 때 필수 작업

**`application.properties` 파일을 직접 생성해야 합니다.**
`.gitignore`에 포함된 파일이라 공유되지 않아요. 
- 경로: backend/src/main/resources/application.properties
노션 gitIgnore 파일 참고
---

### 리뷰 요구사항
fontId를 localStorage에 저장하는 방식 사용 중 — 추후 마이페이지 구현 시 /api/v1/fonts/list API로 대체 예정
폰트 생성 로딩 프로그레스바는 현재 임시 타이머 방식 유지 중 (추후 SSE/WebSocket으로 개선 예정)

