### PR TITLE
[Feat] 사용자 정보 수정, 폰트 삭제, 회원탈퇴

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 
     configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
 
-    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 
     configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
 

--- a/backend/src/main/java/com/example/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/example/backend/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.backend.controller;
 
 import com.example.backend.dto.SignInRequest;
 import com.example.backend.dto.SignUpRequest;
+import com.example.backend.dto.UpdateNameRequest;
 import com.example.backend.dto.UserResponse;
 import com.example.backend.security.JwtProvider;
 import com.example.backend.service.AuthService;
@@ -64,10 +65,42 @@ public class AuthController {
     if (token == null || !jwtProvider.validateToken(token)) {
       return ResponseEntity.status(401).build();
     }
-
     String email = jwtProvider.getEmailFromToken(token);
+    return ResponseEntity.ok(authService.getMyInfo(email));
+  }
 
-    UserResponse response = authService.getMyInfo(email);
-    return ResponseEntity.ok(response);
+  @PatchMapping("/me")
+  public ResponseEntity<UserResponse> updateMe(
+    @CookieValue(name = "accessToken", required = false) String token,
+    @RequestBody UpdateNameRequest request
+  ) {
+    if (token == null || !jwtProvider.validateToken(token)) {
+      return ResponseEntity.status(401).build();
+    }
+    String email = jwtProvider.getEmailFromToken(token);
+    return ResponseEntity.ok(authService.updateName(email, request));
+  }
+
+  @DeleteMapping("/me")
+  public ResponseEntity<String> deleteMe(
+    @CookieValue(name = "accessToken", required = false) String token
+  ) {
+    if (token == null || !jwtProvider.validateToken(token)) {
+      return ResponseEntity.status(401).build();
+    }
+    String email = jwtProvider.getEmailFromToken(token);
+    authService.deleteAccount(email);
+
+    ResponseCookie expiredCookie = ResponseCookie.from("accessToken", "")
+      .httpOnly(true)
+      .secure(false)
+      .path("/")
+      .maxAge(0)
+      .sameSite("Lax")
+      .build();
+
+    return ResponseEntity.ok()
+      .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+      .body("회원탈퇴가 완료되었습니다.");
   }
 }

--- a/backend/src/main/java/com/example/backend/controller/FontController.java
+++ b/backend/src/main/java/com/example/backend/controller/FontController.java
@@ -64,6 +64,22 @@ public class FontController {
         }
     }
 
+    @DeleteMapping("/{fontId}")
+    public ResponseEntity<?> deleteFont(
+        @PathVariable String fontId,
+        @CookieValue(name = "accessToken", required = false) String token
+    ) {
+        if (token == null) {
+            return ResponseEntity.status(401).body("로그인이 필요합니다.");
+        }
+        try {
+            fontService.deleteFont(token, fontId);
+            return ResponseEntity.ok("폰트가 삭제되었습니다.");
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(404).body(e.getMessage());
+        }
+    }
+
     @GetMapping("/download/{fontId}")
     public ResponseEntity<Resource> downloadFont(
         @PathVariable String fontId,

--- a/backend/src/main/java/com/example/backend/dto/UpdateNameRequest.java
+++ b/backend/src/main/java/com/example/backend/dto/UpdateNameRequest.java
@@ -1,0 +1,10 @@
+package com.example.backend.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNameRequest {
+  private String name;
+}

--- a/backend/src/main/java/com/example/backend/entity/User.java
+++ b/backend/src/main/java/com/example/backend/entity/User.java
@@ -28,4 +28,8 @@ public class User {
     this.password = password;
     this.name = name;
   }
+
+  public void updateName(String name) {
+    this.name = name;
+  }
 }

--- a/backend/src/main/java/com/example/backend/service/AuthService.java
+++ b/backend/src/main/java/com/example/backend/service/AuthService.java
@@ -2,8 +2,10 @@ package com.example.backend.service;
 
 import com.example.backend.dto.SignInRequest;
 import com.example.backend.dto.SignUpRequest;
+import com.example.backend.dto.UpdateNameRequest;
 import com.example.backend.dto.UserResponse;
 import com.example.backend.entity.User;
+import com.example.backend.repository.FontRepository;
 import com.example.backend.repository.UserRepository;
 import com.example.backend.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private final UserRepository userRepository;
+  private final FontRepository fontRepository;
   private final BCryptPasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
 
@@ -48,5 +51,23 @@ public class AuthService {
       .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
 
     return new UserResponse(user.getEmail(), user.getName());
+  }
+
+  @Transactional
+  public UserResponse updateName(String email, UpdateNameRequest request) {
+    User user = userRepository.findByEmail(email)
+      .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+    user.updateName(request.getName());
+    return new UserResponse(user.getEmail(), user.getName());
+  }
+
+  @Transactional
+  public void deleteAccount(String email) {
+    User user = userRepository.findByEmail(email)
+      .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+    fontRepository.deleteAll(fontRepository.findByUserOrderByCreatedAtDesc(user));
+    userRepository.delete(user);
   }
 }

--- a/backend/src/main/java/com/example/backend/service/FontService.java
+++ b/backend/src/main/java/com/example/backend/service/FontService.java
@@ -53,6 +53,26 @@ public class FontService {
         return fontRepository.findByUserOrderByCreatedAtDesc(user);
     }
 
+    @Transactional
+    public void deleteFont(String token, String fontId) {
+        User user = getUserFromToken(token);
+
+        Font font = fontRepository.findByFontId(fontId)
+            .filter(f -> f.getUser().getId().equals(user.getId()))
+            .orElseThrow(() -> new RuntimeException("폰트를 찾을 수 없습니다."));
+
+        File dir = new File(font.getTtfPath()).getParentFile();
+        if (dir != null && dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) f.delete();
+            }
+            dir.delete();
+        }
+
+        fontRepository.delete(font);
+    }
+
     @Transactional(readOnly = true)
     public File downloadFont(String token, String fontId) {
         User user = getUserFromToken(token);

--- a/frontend/app/(main)/mypage/page.tsx
+++ b/frontend/app/(main)/mypage/page.tsx
@@ -192,7 +192,7 @@ export default function MyPage() {
           {fonts.length === 0 ? (
             <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-16 text-center">
               <p className="text-gray-400 mb-6">아직 만든 폰트가 없어요.</p>
-              <Button onClick={() => router.push("/scan")}>폰트 만들러 가기</Button>
+              <Button onClick={() => router.push("/")}>폰트 만들러 가기</Button>
             </div>
           ) : (
             <div className="flex flex-col gap-4">

--- a/frontend/app/(main)/mypage/page.tsx
+++ b/frontend/app/(main)/mypage/page.tsx
@@ -2,10 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Download, FileText } from "lucide-react";
-import api from "@/app/lib/axios";
+import { Download, FileText, Pencil, Trash2, User } from "lucide-react";
+import api, { authService } from "@/app/lib/axios";
 import PageHeader from "@/components/ui/PageHeader";
 import Button from "@/components/ui/Button";
+
+interface UserInfo {
+  name: string;
+  email: string;
+}
 
 interface Font {
   fontId: string;
@@ -16,14 +21,28 @@ interface Font {
 
 export default function MyPage() {
   const router = useRouter();
+  const [user, setUser] = useState<UserInfo | null>(null);
   const [fonts, setFonts] = useState<Font[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [nameLoading, setNameLoading] = useState(false);
+
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+  const [withdrawLoading, setWithdrawLoading] = useState(false);
+
   useEffect(() => {
-    const fetchFonts = async () => {
+    const fetchData = async () => {
       try {
-        const response = await api.get("/fonts/list");
-        setFonts(response.data);
+        const [userData, fontsData] = await Promise.all([
+          authService.getMe(),
+          api.get("/fonts/list").then((r) => r.data),
+        ]);
+        setUser(userData);
+        setFonts(fontsData);
       } catch (error: any) {
         if (error.response?.status === 401) {
           router.push("/sign-in");
@@ -32,8 +51,27 @@ export default function MyPage() {
         setLoading(false);
       }
     };
-    fetchFonts();
+    fetchData();
   }, [router]);
+
+  const handleEditName = () => {
+    setNameInput(user?.name ?? "");
+    setIsEditingName(true);
+  };
+
+  const handleSaveName = async () => {
+    if (!nameInput.trim()) return;
+    setNameLoading(true);
+    try {
+      const updated = await authService.updateName(nameInput.trim());
+      setUser(updated);
+      setIsEditingName(false);
+    } catch {
+      alert("이름 수정 중 오류가 발생했습니다.");
+    } finally {
+      setNameLoading(false);
+    }
+  };
 
   const handleDownload = async (fontId: string, fontName: string) => {
     try {
@@ -53,25 +91,108 @@ export default function MyPage() {
     }
   };
 
+  const handleDeleteFont = async (fontId: string) => {
+    if (!window.confirm("폰트를 삭제할까요? 삭제한 폰트는 복구할 수 없어요.")) return;
+    setDeleteLoading(true);
+    try {
+      await api.delete(`/fonts/${fontId}`);
+      setFonts((prev) => prev.filter((f) => f.fontId !== fontId));
+    } catch {
+      alert("폰트 삭제 중 오류가 발생했습니다.");
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const handleWithdraw = async () => {
+    setWithdrawLoading(true);
+    try {
+      await authService.deleteAccount();
+      window.location.href = "/";
+    } catch {
+      alert("회원탈퇴 중 오류가 발생했습니다.");
+      setWithdrawLoading(false);
+      setShowWithdrawModal(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-gray-400">불러오는 중...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       <main className="max-w-4xl mx-auto px-6 pt-16">
-        <PageHeader title="마이페이지" subtitle="내가 만든 폰트를 확인하고 다운로드하세요." />
+        <PageHeader title="마이페이지" />
 
-        <section>
-          <h2 className="text-lg font-bold mb-6 flex items-center gap-2">
-            <FileText size={20} className="text-brand-500" />
+        {/* 사용자 정보 */}
+        <section className="bg-white rounded-3xl border border-gray-100 shadow-sm px-8 py-7 mb-10">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-brand-50 rounded-xl">
+              <User size={18} className="text-brand-500" />
+            </div>
+            <h2 className="text-base font-bold text-gray-800">내 정보</h2>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-400 w-16">이름</span>
+              {isEditingName ? (
+                <div className="flex items-center gap-2 flex-1 ml-4">
+                  <input
+                    autoFocus
+                    value={nameInput}
+                    onChange={(e) => setNameInput(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSaveName()}
+                    onBlur={() => setIsEditingName(false)}
+                    className="flex-1 px-3 py-1.5 text-sm border border-brand-300 rounded-xl outline-none focus:ring-2 focus:ring-brand-200"
+                  />
+                  <button
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={handleSaveName}
+                    disabled={nameLoading}
+                    className="px-3 py-1.5 text-sm font-bold text-brand-600 hover:bg-brand-50 rounded-xl transition disabled:opacity-50"
+                  >
+                    저장
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 flex-1 ml-4">
+                  <span className="text-sm font-medium text-gray-800">{user?.name}</span>
+                  <button
+                    onClick={handleEditName}
+                    className="p-1.5 text-gray-300 hover:text-brand-500 hover:bg-brand-50 rounded-lg transition"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div className="h-px bg-gray-50" />
+
+            <div className="flex items-center">
+              <span className="text-sm text-gray-400 w-16">이메일</span>
+              <span className="text-sm text-gray-800 ml-4">{user?.email}</span>
+            </div>
+          </div>
+        </section>
+
+        {/* 폰트 목록 */}
+        <section className="mb-10">
+          <h2 className="text-base font-bold mb-6 flex items-center gap-2">
+            <FileText size={18} className="text-brand-500" />
             내 폰트 목록
           </h2>
 
-          {loading ? (
-            <div className="text-center py-20 text-gray-400">불러오는 중...</div>
-          ) : fonts.length === 0 ? (
+          {fonts.length === 0 ? (
             <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-16 text-center">
               <p className="text-gray-400 mb-6">아직 만든 폰트가 없어요.</p>
-              <Button onClick={() => router.push("/scan")}>
-                폰트 만들러 가기
-              </Button>
+              <Button onClick={() => router.push("/scan")}>폰트 만들러 가기</Button>
             </div>
           ) : (
             <div className="flex flex-col gap-4">
@@ -81,25 +202,75 @@ export default function MyPage() {
                   className="bg-white rounded-2xl border border-gray-100 shadow-sm px-8 py-6 flex items-center justify-between"
                 >
                   <div>
-                    <p className="text-lg font-bold text-gray-800">{font.fontName}</p>
+                    <p className="text-base font-bold text-gray-800">{font.fontName}</p>
                     <p className="text-sm text-gray-400 mt-1">
                       {font.type === "MANUAL" ? "직접 작성" : "AI 생성"} •{" "}
                       {new Date(font.createdAt).toLocaleDateString("ko-KR")}
                     </p>
                   </div>
-                  <Button
-                    onClick={() => handleDownload(font.fontId, font.fontName)}
-                    className="flex items-center gap-2"
-                  >
-                    <Download size={16} />
-                    TTF 다운로드
-                  </Button>
+
+                  <div className="flex items-center gap-3">
+                    <Button
+                      size="sm"
+                      onClick={() => handleDownload(font.fontId, font.fontName)}
+                      className="flex items-center gap-2"
+                    >
+                      <Download size={14} />
+                      TTF 다운로드
+                    </Button>
+
+                    <button
+                      onClick={() => handleDeleteFont(font.fontId)}
+                      disabled={deleteLoading}
+                      className="p-2 text-gray-300 hover:text-red-400 hover:bg-red-50 rounded-xl transition disabled:opacity-50"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>
           )}
         </section>
+
+        {/* 회원탈퇴 */}
+        <section className="flex justify-end">
+          <button
+            onClick={() => setShowWithdrawModal(true)}
+            className="text-sm text-gray-300 hover:text-red-400 transition underline underline-offset-2"
+          >
+            회원탈퇴
+          </button>
+        </section>
       </main>
+
+      {/* 회원탈퇴 모달 */}
+      {showWithdrawModal && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-6">
+          <div className="bg-white rounded-3xl shadow-xl p-8 w-full max-w-sm">
+            <h3 className="text-lg font-bold text-gray-900 mb-2">정말 탈퇴하시겠어요?</h3>
+            <p className="text-sm text-gray-400 mb-8 leading-relaxed">
+              탈퇴하면 내 폰트와 모든 정보가 <br />
+              영구적으로 삭제되며 복구할 수 없어요.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowWithdrawModal(false)}
+                className="flex-1 py-3 text-sm font-bold text-gray-500 bg-gray-100 hover:bg-gray-200 rounded-2xl transition"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleWithdraw}
+                disabled={withdrawLoading}
+                className="flex-1 py-3 text-sm font-bold text-white bg-red-400 hover:bg-red-500 rounded-2xl transition disabled:opacity-50"
+              >
+                {withdrawLoading ? "처리 중..." : "탈퇴하기"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -10,7 +10,9 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+}
 
+@theme {
   --color-brand-50: #faf5ff;
   --color-brand-100: #f3e8ff;
   --color-brand-200: #e9d5ff;

--- a/frontend/app/lib/axios.ts
+++ b/frontend/app/lib/axios.ts
@@ -46,6 +46,15 @@ export const authService = {
     const response = await api.get("/auth/me");
     return response.data;
   },
+
+  updateName: async (name: string) => {
+    const response = await api.patch("/auth/me", { name });
+    return response.data;
+  },
+
+  deleteAccount: async () => {
+    await api.delete("/auth/me");
+  },
 };
 
 export default api;


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #21 

## 📝작업 내용

**[backend] AuthController, AuthService - 사용자 정보 수정 / 회원탈퇴 API**

- PATCH /api/v1/auth/me — 이름 수정
- DELETE /api/v1/auth/me — 회원탈퇴 (쿠키 만료 + 유저/폰트 DB 삭제)

**[backend] FontController, FontService - 폰트 삭제 API**

- DELETE /api/v1/fonts/{fontId} — 폰트 삭제 (파일 + DB)

**[frontend] app/(main)/mypage/page.tsx - 마이페이지 설정**

- 사용자 정보 섹션 추가 (이름, 이메일 표시)
- 이름 인라인 수정 (연필 아이콘 클릭 → input 전환, 저장 버튼 또는 포커스 벗어나면 취소)
- 폰트 삭제 버튼 (휴지통 아이콘 → window.confirm → 삭제)
- 회원탈퇴 모달 (탈퇴 후 전체 새로고침으로 헤더 상태 초기화)

### 스크린샷 

### 리뷰 요구사항

> 이름 수정 시 저장 버튼 클릭과 input onBlur 충돌 방지를 위해 `onMouseDown={(e) => e.preventDefault()}` 패턴을 사용했습니다.
