### PR TITLE
[fix] Windows 호환 및 STT/생성 타임아웃 오류 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/AutobiographyController.java
+++ b/backend/src/main/java/com/example/backend/controller/AutobiographyController.java
@@ -330,7 +330,8 @@ public class AutobiographyController {
     // ── 공통: Python 실행 헬퍼 ────────────────────────────────────────────────────
     private String runPython(String... args) throws Exception {
         List<String> cmd = new ArrayList<>();
-        cmd.add("python3");
+        String pythonCmd = System.getProperty("os.name").toLowerCase().contains("win") ? "python" : "python3";
+        cmd.add(pythonCmd);
         cmd.addAll(Arrays.asList(args));
 
         ProcessBuilder pb = new ProcessBuilder(cmd);

--- a/frontend/app/(main)/autobiography/page.tsx
+++ b/frontend/app/(main)/autobiography/page.tsx
@@ -300,7 +300,7 @@ export default function AutobiographyPage() {
     try {
       const fd = new FormData();
       fd.append("audio", blob, "recording.webm");
-      const res = await api.post("/autobiography/transcribe", fd);
+      const res = await api.post("/autobiography/transcribe", fd, { timeout: 0 });
       onResult(res.data.text ?? "");
     } catch {
       await new Promise((r) => setTimeout(r, 1000));
@@ -555,7 +555,7 @@ export default function AutobiographyPage() {
       else if (selectedFontId) fd.append("font_id", selectedFontId);
       images.forEach((img) => fd.append("images", img));
 
-      const res = await api.post("/autobiography/generate", fd);
+      const res = await api.post("/autobiography/generate", fd, { timeout: 0 });
       if (res.status === 200) {
         progressIntervalRef.current && clearInterval(progressIntervalRef.current);
         if (res.data.id) sessionStorage.setItem("autobiography_id", String(res.data.id));


### PR DESCRIPTION
## 연관 작업
#34 머지 이후 발견된 치명적 오류 긴급 수정

## 변경 사항
- [x] Windows에서 `python3` 명령어 인식 안 되는 문제 수정 → OS 감지 후 Windows는 `python`, Mac/Linux는 `python3` 자동 선택
- [x] STT(음성 변환) 및 자서전 생성 API 타임아웃 오류 수정 → Whisper + LLM + PDF 생성은 10초 넘게 걸리는데 기본 타임아웃(10s)에 걸려 실패하던 문제

## 원인
- Windows 팀원 테스트 중 자서전 기능 전체 실패 확인
- `axios` 기본 타임아웃 10초가 Whisper 처리 시간보다 짧아 오류 발생

## 테스트 체크리스트
- [ ] Windows에서 자서전 STT 정상 동작 확인
- [ ] 자서전 생성 완료까지 타임아웃 없이 대기되는지 확인