### PR TITLE
[fix] 자서전 API 타임아웃 오류 수정

### DIFF
--- a/frontend/app/(main)/autobiography/page.tsx
+++ b/frontend/app/(main)/autobiography/page.tsx
@@ -479,7 +479,7 @@ export default function AutobiographyPage() {
           category: q.category,
           answer: transcriptions[i],
         })),
-      });
+      }, { timeout: 0 });
       const questions: string[] = res.data.followups ?? [];
       if (questions.length === 0) { goToKeyword(); return; }
       setFollowupQuestions(questions);
@@ -502,7 +502,7 @@ export default function AutobiographyPage() {
         name, birth: birthDate,
         transcriptions,
         followup_transcriptions: followupTranscriptions,
-      });
+      }, { timeout: 0 });
       setKeywordCandidates(res.data.keywords ?? []);
     } catch {
       setKeywordCandidates([]);
@@ -524,7 +524,7 @@ export default function AutobiographyPage() {
         transcriptions,
         followup_transcriptions: followupTranscriptions,
         selected_keywords: keywords ?? selectedKeywords,
-      });
+      }, { timeout: 0 });
       setTitleInput(res.data.title ?? "");
     } catch {
       /* 실패 시 빈 상태 유지 */


### PR DESCRIPTION
## 변경 사항
- `generate-followups`, `suggest` API 호출에 `{ timeout: 0 }` 추가
- axios 기본 타임아웃(10초)으로 인해 OpenAI API 응답 전에 끊겨 `{}` 에러 발생하던 문제 수정